### PR TITLE
Refactor: follow Go naming conventions, update module, fix imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+
+# Output of `go build`
+/bin/
+/build/
+/dist/
+
+# Vendor directory (if you're not using Go modules)
+/vendor/
+
+# Dependency directories (remove if using Go modules)
+Godeps/
+
+# IDE/editor junk
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Coverage reports
+*.out
+*.coverprofile
+
+# Temporary files
+*.tmp
+*.temp

--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,6 @@
 /build/
 /dist/
 
-# Vendor directory (if you're not using Go modules)
-/vendor/
-
-# Dependency directories (remove if using Go modules)
-Godeps/
-
 # IDE/editor junk
 .idea/
 .vscode/
@@ -37,3 +31,5 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+
+mini_pytorch

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/mini_Pytorch.iml
+++ b/.idea/mini_Pytorch.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/mini_Pytorch.iml" filepath="$PROJECT_DIR$/.idea/mini_Pytorch.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module Github_campaign
+module mini_pytorch

--- a/loader/matrix.go
+++ b/loader/matrix.go
@@ -1,4 +1,4 @@
-package Loader
+package loader
 
 import (
 	"bufio"

--- a/main.go
+++ b/main.go
@@ -1,31 +1,31 @@
 package main
 
 import (
-	"Github_campaign/Loader"
-	"Github_campaign/Tensor"
 	"fmt"
 	"log"
+	"mini_pytorch/loader"
+	"mini_pytorch/tensor"
 )
 
 func main() {
 	// I have created a simple Tensor 2D slice here
-	aData, err := Loader.GetUserMatrix("A")
+	aData, err := loader.GetUserMatrix("A")
 	if err != nil {
 		log.Fatalf("Error getting ternsor A : %v", err)
 	}
-	bData, err := Loader.GetUserMatrix("B")
+	bData, err := loader.GetUserMatrix("B")
 	if err != nil {
 		log.Fatalf("Error getting tensor B : %v", err)
 	}
 	// here it is returning two things: 1. a and 2. err
-	a, err := Tensor.NewTensor(aData)
+	a, err := tensor.NewTensor(aData)
 	// I am checking here that whether the error occurred or not
 	if err != nil {
 		fmt.Println("Error creating Tensor A", err)
 		return
 	}
 
-	b, err := Tensor.NewTensor(bData)
+	b, err := tensor.NewTensor(bData)
 	if err != nil {
 		fmt.Println("Error creating Tensor B", err)
 		return
@@ -70,7 +70,8 @@ func main() {
 	fmt.Println("Result of the matrix multiplication : ")
 	mul.Print()
 
-	addS, err := a.AddScalar()
+	// TODO: Hardcoded value
+	addS, err := a.AddScalar(5.0)
 	if err != nil {
 		log.Fatalf("error in the AddScalar function: %v", err)
 	}
@@ -90,7 +91,7 @@ func main() {
 	}
 	fmt.Printf("Shape of matrix  Rows :%d , Cols: %d", rows, cols)
 
-	random, err := Tensor.Random(4, 4)
+	random, err := tensor.Random(4, 4)
 	if err != nil {
 		log.Fatalf("error in generatting the random matrix %v", err)
 	}

--- a/tensor/basic_ops.go
+++ b/tensor/basic_ops.go
@@ -1,4 +1,4 @@
-package Tensor
+package tensor
 
 import (
 	"errors"

--- a/tensor/init.go
+++ b/tensor/init.go
@@ -1,4 +1,4 @@
-package Tensor
+package tensor
 
 import (
 	"errors"

--- a/tensor/manipulation.go
+++ b/tensor/manipulation.go
@@ -1,4 +1,4 @@
-package Tensor
+package tensor
 
 import (
 	"errors"

--- a/tensor/matmul.go
+++ b/tensor/matmul.go
@@ -1,4 +1,4 @@
-package Tensor
+package tensor
 
 import (
 	"errors"

--- a/tensor/reduction.go
+++ b/tensor/reduction.go
@@ -1,4 +1,4 @@
-package Tensor
+package tensor
 
 import (
 	"errors"

--- a/tensor/tensor.go
+++ b/tensor/tensor.go
@@ -1,4 +1,4 @@
-package Tensor
+package tensor
 
 import (
 	"errors"


### PR DESCRIPTION
This PR refactors the project structure to align with Go's standard conventions:

- Renamed folders and files to lowercase (loader/, tensor/, manipulation.go, reduction.go)
- Updated module name in go.mod to "mini_pytorch"
- Fixed import paths to match the new module name and folder structure
- Fixed missing argument in AddScalar by passing a hardcoded 5.0 value temporarily
- Added .gitignore to exclude binary and IDE-specific files

No functional changes have been made.

Future improvement: Allow dynamic user input for AddScalar value to avoid the hardcoded fix.
